### PR TITLE
require comment on doctrine type

### DIFF
--- a/src/Doctrine/Type/BlockConfigurationType.php
+++ b/src/Doctrine/Type/BlockConfigurationType.php
@@ -47,4 +47,9 @@ final class BlockConfigurationType extends JsonType
             return new InvalidConfiguration($rawConfiguration);
         }
     }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
this prevents doctrine to always think there is a difference in db and recreate migrations